### PR TITLE
Adding binding parameter to host call binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var functions = [_]wapc.Function{
 };
 
 fn sayHello(allocator: *mem.Allocator, payload: []u8) ![]u8 {
-    const hostHello = try wapc.hostCall(allocator, &"sample", &"hello", &"Simon");
+    const hostHello = try wapc.hostCall(allocator, &"myBinding", &"sample", &"hello", &"Simon");
     const prefix = "Hello, ";
     const message = try allocator.alloc(u8, prefix.len + payload.len + hostHello.len + 1);
     mem.copy(u8, message, &prefix);

--- a/wapc.zig
+++ b/wapc.zig
@@ -2,7 +2,7 @@ extern "wapc" fn __guest_request(operation_ptr: [*]u8, payload_ptr: [*]u8) void;
 extern "wapc" fn __guest_response(ptr: [*]u8, len: usize) void;
 extern "wapc" fn __guest_error(ptr: [*]u8, len: usize) void;
 
-extern "wapc" fn __host_call(namespace_ptr: [*]u8, namespace_len: usize, operation_ptr: [*]u8, operation_len: usize, payload_ptr: [*]u8, payload_len: usize) bool;
+extern "wapc" fn __host_call(binding_ptr: [*]u8, binding_len: usize, namespace_ptr: [*]u8, namespace_len: usize, operation_ptr: [*]u8, operation_len: usize, payload_ptr: [*]u8, payload_len: usize) bool;
 extern "wapc" fn __host_response_len() usize;
 extern "wapc" fn __host_response(ptr: [*]u8) void;
 extern "wapc" fn __host_error_len() usize;
@@ -49,8 +49,8 @@ pub fn handleCall(operation_size: usize, payload_size: usize, fns: []Function) b
     return false;
 }
 
-pub fn hostCall(allocator: *mem.Allocator, namespace: []u8, operation: []u8, payload: []u8) ![]u8 {
-    const result = __host_call(namespace.ptr, namespace.len, operation.ptr, operation.len, payload.ptr, payload.len);
+pub fn hostCall(allocator: *mem.Allocator, binding: []u8, namespace: []u8, operation: []u8, payload: []u8) ![]u8 {
+    const result = __host_call(binding.ptr, binding.len, namespace.ptr, namespace.len, operation.ptr, operation.len, payload.ptr, payload.len);
     if (!result) {
         const errorLen = __host_error_len();
         const errorPrefix = "Host error: ";


### PR DESCRIPTION
Adding a `binding` parameter to `__host_call` to allow the Host to route the call between potentially multiple components that serve the same namespace.