### PR TITLE
Upgrades to zig 0.9 and more

### DIFF
--- a/wapc.zig
+++ b/wapc.zig
@@ -8,53 +8,66 @@ extern "wapc" fn __host_response(ptr: [*]u8) void;
 extern "wapc" fn __host_error_len() usize;
 extern "wapc" fn __host_error(ptr: [*]u8) void;
 
-extern fn __console_log(ptr: [*]u8, len: usize) void;
-
 const std = @import("std");
 const mem = std.mem;
 const heap = std.heap;
 
 pub const Function = struct {
-    pub const Error = error{HostError,OutOfMemory};
-    name: []u8,
+    name: []const u8,
     invoke: fn (
-        allocator: *mem.Allocator,
+        allocator: mem.Allocator,
         payload: []u8,
-    ) Error![]u8,
+    ) anyerror![]u8,
 };
 
-pub fn handleCall(operation_size: usize, payload_size: usize, fns: []Function) bool {
-    var sbuf: [1000]u8 = undefined;
-    var allocator = &std.heap.FixedBufferAllocator.init(sbuf[0..]).allocator;
+fn guestError(allocator: mem.Allocator, err: anyerror) !void {
+    var message = std.ArrayList(u8).init(allocator);
+    defer message.deinit();
+    try message.appendSlice("guest error: ");
+    try message.appendSlice(@errorName(err));
+    __guest_error(@ptrCast([*]u8, message.items), message.items.len);
+}
 
-    var operation_buf = allocator.alloc(u8, operation_size) catch |err| return false;
-    var payload_buf = allocator.alloc(u8, payload_size) catch |err| return false;
+fn functionNotFoundError(allocator: mem.Allocator, operation: []u8) !void {
+    var message = std.ArrayList(u8).init(allocator);
+    defer message.deinit();
+    try message.appendSlice("Could not find function ");
+    try message.appendSlice(operation);
+    __guest_error(@ptrCast([*]u8, message.items), message.items.len);
+}
+
+pub fn handleCall(allocator: mem.Allocator, operation_size: usize, payload_size: usize, comptime fns: []const Function) bool {
+    var operation_buf = allocator.alloc(u8, operation_size) catch return false;
+    defer allocator.free(operation_buf);
+
+    var payload_buf = allocator.alloc(u8, payload_size) catch return false;
+    defer allocator.free(payload_buf);
+
     __guest_request(operation_buf.ptr, payload_buf.ptr);
 
-    for (fns) |function| {
+    inline for (fns) |function| {
         if (mem.eql(u8, operation_buf, function.name)) {
-            const response = function.invoke(allocator, payload_buf) catch |err| return false;
+            const response = function.invoke(allocator, payload_buf) catch |err| {
+                guestError(allocator, err) catch return false;
+                return false;
+            };
             __guest_response(response.ptr, response.len);
-
             return true;
         }
     }
 
-    const functionNotFound = "Could not find function ";
-    const message = allocator.alloc(u8, functionNotFound.len + operation_buf.len) catch |err| return false;
-    mem.copy(u8, message, &functionNotFound);
-    mem.copy(u8, message[functionNotFound.len..], operation_buf);
-    __guest_error(message.ptr, message.len);
-
+    functionNotFoundError(allocator, operation_buf) catch return false;
     return false;
 }
 
-pub fn hostCall(allocator: *mem.Allocator, binding: []u8, namespace: []u8, operation: []u8, payload: []u8) ![]u8 {
+pub fn hostCall(allocator: mem.Allocator, binding: []u8, namespace: []u8, operation: []u8, payload: []u8) ![]u8 {
     const result = __host_call(binding.ptr, binding.len, namespace.ptr, namespace.len, operation.ptr, operation.len, payload.ptr, payload.len);
     if (!result) {
         const errorLen = __host_error_len();
         const errorPrefix = "Host error: ";
-        const message = allocator.alloc(u8, errorPrefix.len +errorLen) catch |err| return error.HostError;
+        const message = allocator.alloc(u8, errorPrefix.len + errorLen) catch return error.HostError;
+        defer allocator.free(message);
+
         mem.copy(u8, message, &errorPrefix);
         __host_error(message.ptr + errorPrefix.len);
         __guest_error(message.ptr, message.len);


### PR DESCRIPTION
I was using this library as a foundation for https://github.com/trashhalo/create-zig-wasm-app
Here are the changes I made a long the way. Let me know if you want me to try and cut this up to be smaller.

1. zig 0.9 support. allocator changes mostly
2. be more forgiving when functions return implied error union types. (Function takes anyerror now)
3. allow functions to not return anything. Function now is optional. send a 0 len pointer back to client in this case
4. switch some things to const to allow inlining the function call loop
5. when a function errors serialize the name back to the client so you can get an idea of what went wrong
6. using an arraylist instead of doing len math to alloc the exact right number of bytes.
7. give caller control over allocator creation
